### PR TITLE
Add file-name input property for preventing hardcoded file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,15 @@ Client Id and the Client Key for that we need to create a new API key in the App
 
 ### `file-path`
 
-**Required** file path tp upload
+**Required** File path to upload
+
+### `file-name` (String) default app-release
+
+**Optional** Desired file name seen on AppGallery Connect after the upload. This will define a custom file name on AppGallery package file list. If not used, the file name shown on AppGallery Connect will be always app-release.extension.
 
 ### `submit` (BOOL) default false
 
-whether or not to submit automatically
+**Optional** whether or not to submit automatically
 
 ## Sample usage
 
@@ -46,4 +50,5 @@ whether or not to submit automatically
           app-id: ${{secrets.HUAWEI_APP_ID}}
           file-extension: "apk"
           file-path: "apk/release/app-release.apk"
+          file-name: "MyAppName-1.0.0"
           submit: true

--- a/action.yml
+++ b/action.yml
@@ -19,8 +19,12 @@ inputs:
     required: true
     default: "apk"
   file-path: # File name extension apk/rpk/pdf/jpg/jpeg/png/bmp/mp4/mov/aab.
-    description: "file path tp upload"
+    description: "file path to upload"
     required: true
+  file-name: # File name can be customized, default value is app-release.
+    description: "desired file name to upload"
+    required: false
+    default: 'app-release'
   submit:
     description: "whether or not to submit automatically"
     required: false

--- a/index.js
+++ b/index.js
@@ -120,14 +120,16 @@ function uploadFile({
  * @param  {} appId
  * @param  {} clientId
  * @param  {} token
+ * @param  {} fileExt
+ * @param  {} fileName
  */
-function updateAppFileInfo({ fileDestUrl, size, appId, clientId, token, fileExt }) {
+function updateAppFileInfo({ fileDestUrl, size, appId, clientId, token, fileExt, fileName }) {
   console.log("Update App File Info .... ⌛️");
   var data = JSON.stringify({
     fileType: "5",
     files: [
       {
-        fileName: `app-release.${fileExt}`,
+        fileName: `${fileName}.${fileExt}`,
         fileDestUrl: fileDestUrl,
         size,
       },
@@ -148,7 +150,7 @@ function updateAppFileInfo({ fileDestUrl, size, appId, clientId, token, fileExt 
   return axios(config);
 }
 
-async function startDeply({ clientId, clientKey, appId, fileExt, filePath, submit }) {
+async function startDeply({ clientId, clientKey, appId, fileExt, filePath, fileName, submit }) {
   try {
     const newToken = await getToken({
       clientId,
@@ -180,7 +182,8 @@ async function startDeply({ clientId, clientKey, appId, fileExt, filePath, submi
       size: uploadInfo.data.result.UploadFileRsp.fileInfoList[0].size,
       fileDestUrl:
         uploadInfo.data.result.UploadFileRsp.fileInfoList[0].fileDestUlr,
-      fileExt
+      fileExt,
+      fileName
     });
     if (updateFileInfo.data.ret.msg === "success") {
       console.log("successfully uploaded 🎉🎉🎉🎉🎉🎉");
@@ -211,13 +214,14 @@ try {
   const appId = core.getInput("app-id");
   const fileExt = core.getInput("file-extension");
   const filePath = core.getInput("file-path");
+  const fileName = core.getInput("file-name");
   const submit = core.getInput("submit");
 
   console.log(
     chalk.yellow(figlet.textSync("AppGallery", { horizontalLayout: "full" }))
   );
 
-  startDeply({ clientId, clientKey, appId, fileExt, filePath, submit });
+  startDeply({ clientId, clientKey, appId, fileExt, filePath, fileName, submit });
 } catch (error) {
   core.setFailed(error.message);
 }


### PR DESCRIPTION
**Problem:**
The APK (or other AAB) is always being uploaded as app-release.apk file name, and that's the name that is visible on AppGallery. 
Issue: [https://github.com/muhamedzeema/appgallery-deply-action/issues/4](https://github.com/muhamedzeema/appgallery-deply-action/issues/4)

**Solution:**
Created an optional input type (_file-name_) in this Github Action so we could define a desired file-name.
Example:
```
- name: Deploy to Huawei App Gallery
  uses: muhamedzeema/appgallery-deply-action@main
  with:
    client-id: ${{secrets.HUAWEI_CLIENT_ID}}
    client-key: ${{secrets.HUAWEI_CLIENT_KEY}}
    app-id: ${{secrets.HUAWEI_APP_ID}}
    file-extension: "apk"
    file-path: "apk/release/app-release.apk"
    file-name: "MyAppName-1_0_0"
    submit: true
```

**Tests:**
Tested with and without the file-name input and it's working as supposed.
## With `file-name: "MyAppName-1_0_0"`
<img width="876" alt="MyAppName_appgallery" src="https://user-images.githubusercontent.com/12532273/149363267-a2335731-aa79-4848-bd0c-742d22ffc73b.png">

## Without file-name input
<img width="903" alt="app-release_appgallery" src="https://user-images.githubusercontent.com/12532273/149363294-634e1e54-7cd5-415e-93c5-c7c4cc44198d.png">

