### PR TITLE
[Hotfix] Fix submit input type to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ async function startDeply({ clientId, clientKey, appId, fileExt, filePath, fileN
     });
     if (updateFileInfo.data.ret.msg === "success") {
       console.log("successfully uploaded 🎉🎉🎉🎉🎉🎉");
-      if (submit) {
+      if (submit === 'true') {
         const submitResult = await submitApp({
           appId,
           clientId,
@@ -195,10 +195,10 @@ async function startDeply({ clientId, clientKey, appId, fileExt, filePath, fileN
         });
         if (submitResult.data.ret.msg === "success") {
           console.log("successfully submitted 🎉🎉🎉🎉🎉🎉");
-	} else {
-          console.log(submitResult.data.ret.msg);
-          core.setFailed(submitResult.data.ret.msg);
-	}
+        } else {
+              console.log(submitResult.data.ret.msg);
+              core.setFailed(submitResult.data.ret.msg);
+        }
       }
     } else {
       core.setFailed(updateFileInfo.data.ret.msg);


### PR DESCRIPTION
**Problem**
Action is always publishing the app even with `submit` set to `false`. I can check the logs and see the `successfully submitted 🎉🎉🎉🎉🎉🎉` message if I set submit to `false` or `true`. 

Issue: [https://github.com/muhamedzeema/appgallery-deply-action/issues/6](https://github.com/muhamedzeema/appgallery-deply-action/issues/6)


**Solution**
Replace the if condition `if (submit) {}` (is always being executed) with:
```
if(submit === 'true'){
   //submit code here
}
```


**Tests**
After some tests and reading the docs, the `input` type will collect the `submit` option as string (and not `boolean` as it is described in the [readme file](https://github.com/muhamedzeema/appgallery-deply-action/blob/main/README.md?plain=1#L38)). So the if condition `if(submit){}` is always being executed.

A quick test doing a `console.log(typeof submit)` retuned `string`. So the solution is to replace the if condition here https://github.com/muhamedzeema/appgallery-deply-action/blob/main/index.js#L190 with: 
```
if(submit === 'true'){
   //submit code here
}
```

## Working version with `submit: false` (only upload)
<img width="603" alt="app-gallery-submit-false" src="https://user-images.githubusercontent.com/12532273/149534931-8acfb868-2517-47d2-a13e-834aa4da5510.png">

## Working version with `submit: true` (upload and submit)
<img width="616" alt="app-gallery-submit-true_" src="https://user-images.githubusercontent.com/12532273/149537600-1217d76b-4007-4b23-a70a-79fe79460bcd.png">


