### PR TITLE
[Chore] Bump to node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,5 +30,5 @@ inputs:
     required: false
     default: false
 runs:
-  using: "node12"
+  using: "node16"
   main: "index.js"


### PR DESCRIPTION
**Problem**
Action is using `node 12`, and now Github will remove that node version from their Github runners machines, forcing `node 16` instead (like stated [here](https://github.blog/changelog/2023-07-17-github-actions-removal-of-node12-from-the-actions-runner/)).

Issue: [https://github.com/muhamedzeema/appgallery-deply-action/issues/9](https://github.com/muhamedzeema/appgallery-deply-action/issues/9)


**Solution**
Replace the `node 12` with `node 16`.


**Tests**
Tested with a `fake_test.apk` file, not uploading to appGallery but for testing if the action would build normally (it does, so the action is working fine with `node 16` ✅  ).

<img width="589" alt="node_16_test_action" src="https://github.com/muhamedzeema/appgallery-deply-action/assets/12532273/78ea4e1b-eb88-40f8-ba1f-95d4f5874745">
